### PR TITLE
iyelik ekli de da/den dan ekleri

### DIFF
--- a/code/__HELPERS/localization.dm
+++ b/code/__HELPERS/localization.dm
@@ -114,10 +114,11 @@
 					return "[rawtext]'ye"
 
 /// Locative Suffix | -de, -da / -te, -ta
-/proc/locale_suffix_locative(rawtext)
+/proc/locale_suffix_locative(rawtext, possessive_suffix = FALSE)
 	var/text = replacetext(rawtext," ","")
 	var/static/list/consonant_assimilation = list("ç", "f", "h", "k", "s", "ş", "t", "p")
 	var/list/charlist = vowelcatcher(text)
+	possessive_suffix = possessive_suffix && !(rawtext in GLOB.skip_possessive_suffix)
 	switch(charlist[1])
 		if(NUMBER)
 			switch(charlist[2])
@@ -142,15 +143,16 @@
 		if(VOWEL)
 			switch(charlist[2])
 				if("e","i","ü","ö")
-					return "[rawtext]'de"
+					return "[rawtext]'[possessive_suffix ? "n":""]de"
 				if("a","ı","o","u")
-					return "[rawtext]'da"
+					return "[rawtext]'[possessive_suffix ? "n":""]da"
 
 /// Ablative Suffix | -den, -dan / -ten, -tan
-/proc/locale_suffix_ablative(rawtext)
+/proc/locale_suffix_ablative(rawtext, possessive_suffix = FALSE)
 	var/text = replacetext(rawtext," ","")
 	var/static/list/consonant_assimilation = list("ç", "f", "h", "k", "s", "ş", "t", "p")
 	var/list/charlist = vowelcatcher(text)
+	possessive_suffix = possessive_suffix && !(rawtext in GLOB.skip_possessive_suffix)
 	switch(charlist[1])
 		if(NUMBER)
 			switch(charlist[2])
@@ -175,9 +177,9 @@
 		if(VOWEL)
 			switch(charlist[2])
 				if("a","ı","o","u")
-					return "[rawtext]'dan"
+					return "[rawtext]'[possessive_suffix ? "n" : ""]dan"
 				if("e","i","ü","ö")
-					return "[rawtext]'den"
+					return "[rawtext]'[possessive_suffix ? "n" : ""]den"
 
 /// Genitive Suffix| -in, -un / -nin, -nun
 /proc/locale_suffix_genitive(rawtext, quotation = TRUE)

--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -136,3 +136,5 @@ GLOBAL_VAR(obfs_z)
 
 /// List of giant lizards that are alive.
 GLOBAL_LIST_EMPTY(giant_lizards_alive)
+
+GLOBAL_LIST_INIT(skip_possessive_suffix, list("Weyland-Yutani", "ARES ve APOLLO"))

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -209,9 +209,9 @@
 
 /datum/job/proc/generate_entry_message()
 	if(!entry_message_intro)
-		entry_message_intro = "[title]'sın!"
+		entry_message_intro = locale_suffix_genitive("[title]'s", FALSE)
 	if(!entry_message_end)
-		entry_message_end = "[title] olarak [supervisors]'ndan emir alırsın. Özel durumlar bunu değiştirebilir!"
+		entry_message_end = "[title] olarak [locale_suffix_ablative(supervisors, TRUE)] emir alırsın. Özel durumlar bunu değiştirebilir!"
 	return "[entry_message_intro]<br>[entry_message_body]<br>[entry_message_end]"
 
 /datum/job/proc/announce_entry_message(mob/living/carbon/human/H, datum/money_account/M, whitelist_status) //The actual message that is displayed to the mob when they enter the game as a new player.


### PR DESCRIPTION
# PR hakkında

<!-- Bu yazıyı kaldırıp PR'ın ana sebebini açıkla.
Değişikliklerini test edip etmediğini belirt.-->
de da eki possessive_suffix argumenti true olunca ve kelime skip_possessive_suffix listesinde yoksa de da yerine nde nda şeklinde olur

# Oyun için neden gerekli
Daha iyi Türkçe 🇹🇷 🇹🇷 
# Fotoğraflar
![image](https://github.com/user-attachments/assets/47234159-657c-4278-b125-225390937ff5)

![image](https://github.com/user-attachments/assets/944625b7-f195-4e54-9a59-97092769cf04)

# Changelog

<!-- Burda değiştirmediğiniz kısımları silebilirsiniz.
Örneğin, eğer sadece sprite eklediyseniz imageadd dışında diğerlerini silip, imageadd kısmına ne eklediğinizi açıklayın.

Eğer github kullanıcı adınız ckeyiniz ile uyuşmuyor ise üstteki CL kısmına ckeyinizi yazın. Ör; :cl:bubenimckeyim -->

:cl: Rengan
fix: Oyuna giriş yazısındaki kötü gözüken Türkçe yazılar düzeltildi.
/:cl:
